### PR TITLE
feat: add paused tray icon overlay and pause duration submenu

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -304,12 +304,12 @@ const startScreenStills = async () => {
     }
 };
 
-const pauseScreenStills = async () => {
+const pauseScreenStills = async ({ durationMs } = {}) => {
     if (!screenStillsController) {
         return { ok: true, skipped: true };
     }
     try {
-        const result = await screenStillsController.manualPause();
+        const result = await screenStillsController.manualPause({ durationMs });
         if (result && result.ok === false) {
             handleStillsError({ message: result.message || 'Failed to pause capturing.' });
         }
@@ -328,7 +328,7 @@ const refreshTrayMenu = () => {
     }
 };
 
-const handleRecordingToggleAction = async () => {
+const handleRecordingToggleAction = async ({ durationMs } = {}) => {
     if (!screenStillsController) {
         console.warn('Recording toggle action ignored: controller unavailable');
         return { ok: false, message: 'Capture controller unavailable.' };
@@ -340,12 +340,14 @@ const handleRecordingToggleAction = async () => {
     if (isPaused) {
         const result = await startScreenStills();
         refreshTrayMenu();
+        refreshTrayIcon();
         return result;
     }
 
     if (isRecording) {
-        const result = await pauseScreenStills();
+        const result = await pauseScreenStills({ durationMs });
         refreshTrayMenu();
+        refreshTrayIcon();
         return result;
     }
 
@@ -410,6 +412,8 @@ const notifyScreenStillsStateChanged = () => {
 const handleRecordingStateTransition = (transition) => {
   handleRecordingOffReminderTransition(transition);
   notifyScreenStillsStateChanged();
+  refreshTrayMenu();
+  refreshTrayIcon();
 };
 
 const getTrayRecordingActionLabel = () => {
@@ -580,9 +584,11 @@ function createTray() {
 
     const getTrayIcon = () => {
         const trayIconState = getTrayIconState();
+        const state = typeof getCurrentScreenStillsState === 'function' ? getCurrentScreenStillsState() : {};
         return createTrayIcon({
             defaultIconPath: trayIconPath,
-            isDarkMode: nativeTheme.shouldUseDarkColors === true
+            isDarkMode: nativeTheme.shouldUseDarkColors === true,
+            isPaused: state.manualPaused === true
         });
     };
 
@@ -609,8 +615,8 @@ function createTray() {
     nativeTheme.on('updated', updateTrayIcon);
 
     trayHandlers = {
-        onRecordingPause: () => {
-            void handleRecordingToggleAction();
+        onRecordingPause: (durationMs) => {
+            void handleRecordingToggleAction({ durationMs });
         },
         onOpenSettings: () => openSettingsWindow({ reason: 'tray' }),
         onQuit: quitApp,

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,6 +1,24 @@
 const { isCaptureActiveState } = require('./recording-status-indicator')
 const { microcopy } = require('./microcopy')
 
+const PAUSE_DURATIONS = [
+  { label: 'Pause for 5 minutes', durationMs: 5 * 60 * 1000 },
+  { label: 'Pause for 10 minutes', durationMs: 10 * 60 * 1000 },
+  { label: 'Pause for 30 minutes', durationMs: 30 * 60 * 1000 },
+  { label: 'Pause for 1 hour', durationMs: 60 * 60 * 1000 }
+]
+
+function formatPausedLabel(remainingMs) {
+  const remaining = typeof remainingMs === 'number' ? remainingMs : 0
+  if (remaining > 0) {
+    const totalSeconds = Math.ceil(remaining / 1000)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `Paused \u2014 ${minutes}:${String(seconds).padStart(2, '0')} remaining`
+  }
+  return 'Paused'
+}
+
 function buildTrayMenuTemplate ({
   onRecordingPause,
   onOpenSettings,
@@ -12,12 +30,25 @@ function buildTrayMenuTemplate ({
   const stillsState = recordingState && typeof recordingState === 'object' ? recordingState.state : ''
   const isRecording = isCaptureActiveState(stillsState)
   const isPaused = Boolean(recordingPaused || (recordingState && recordingState.manualPaused))
-  const recordingLabel = isPaused
-    ? microcopy.tray.recording.pausedFor10MinClickToResume
-    : isRecording
-      ? microcopy.tray.recording.clickToPauseFor10Min
-      : microcopy.tray.recording.startCapturing
-  const recordingItem = { label: recordingLabel, click: onRecordingPause }
+  const pauseRemainingMs = recordingState && typeof recordingState.pauseRemainingMs === 'number'
+    ? recordingState.pauseRemainingMs
+    : 0
+
+  let recordingItem
+  if (isPaused) {
+    recordingItem = { label: formatPausedLabel(pauseRemainingMs), toolTip: 'Click to resume', click: onRecordingPause }
+  } else if (isRecording) {
+    recordingItem = {
+      label: 'Capturing',
+      submenu: PAUSE_DURATIONS.map(({ label, durationMs }) => ({
+        label,
+        click: () => onRecordingPause(durationMs || undefined)
+      }))
+    }
+  } else {
+    recordingItem = { label: microcopy.tray.recording.startCapturing, click: onRecordingPause }
+  }
+
   if (recordingStatusIcon) {
     recordingItem.icon = recordingStatusIcon
   }
@@ -30,4 +61,4 @@ function buildTrayMenuTemplate ({
   ]
 }
 
-module.exports = { buildTrayMenuTemplate }
+module.exports = { buildTrayMenuTemplate, PAUSE_DURATIONS, formatPausedLabel }

--- a/src/screen-stills/controller.js
+++ b/src/screen-stills/controller.js
@@ -56,6 +56,7 @@ function createScreenStillsController(options = {}) {
   let manualPaused = false;
   let manualPauseStartedAt = null;
   let pauseTimer = null;
+  let activePauseDurationMs = pauseDurationMs;
   let activeSessionId = null;
   let lastPresenceState = null;
   let startRetryTimer = null;
@@ -142,6 +143,7 @@ function createScreenStillsController(options = {}) {
   function clearManualPauseState() {
     manualPaused = false;
     manualPauseStartedAt = null;
+    activePauseDurationMs = pauseDurationMs;
     clearPauseTimer();
   }
 
@@ -150,7 +152,7 @@ function createScreenStillsController(options = {}) {
       return 0;
     }
     const elapsedMs = Math.max(0, clock.now() - manualPauseStartedAt);
-    return Math.max(0, pauseDurationMs - elapsedMs);
+    return Math.max(0, activePauseDurationMs - elapsedMs);
   }
 
   function clearStartRetryTimer() {
@@ -238,9 +240,9 @@ function createScreenStillsController(options = {}) {
         return;
       }
       clearManualPauseState();
-      logger.log('Recording pause window elapsed', { durationMs: pauseDurationMs });
+      logger.log('Recording pause window elapsed', { durationMs: activePauseDurationMs });
       syncPresenceState('pause-elapsed');
-    }, pauseDurationMs);
+    }, activePauseDurationMs);
     if (pauseTimer && typeof pauseTimer.unref === 'function') {
       pauseTimer.unref();
     }
@@ -459,25 +461,27 @@ function createScreenStillsController(options = {}) {
     return { ok: true };
   }
 
-  async function manualPause() {
+  async function manualPause({ durationMs } = {}) {
     if (!settings.enabled) {
       return { ok: false, message: 'Recording is disabled.' };
     }
     resetStartRetry();
     if (manualPaused) {
+      activePauseDurationMs = (Number.isFinite(durationMs) && durationMs > 0) ? durationMs : pauseDurationMs;
       manualPauseStartedAt = clock.now();
       schedulePauseResume();
-      logger.log('Recording pause extended', { durationMs: pauseDurationMs });
+      logger.log('Recording pause extended', { durationMs: activePauseDurationMs });
       return { ok: true, alreadyPaused: true };
     }
     if (state !== STATES.RECORDING && state !== STATES.IDLE_GRACE) {
       return { ok: false, message: 'Recording is not active.' };
     }
+    activePauseDurationMs = (Number.isFinite(durationMs) && durationMs > 0) ? durationMs : pauseDurationMs;
     manualPaused = true;
     manualPauseStartedAt = clock.now();
     pendingStart = false;
     schedulePauseResume();
-    logger.log('Recording paused manually', { durationMs: pauseDurationMs });
+    logger.log('Recording paused manually', { durationMs: activePauseDurationMs });
     await stopRecording('manual-pause');
     return { ok: true };
   }

--- a/src/tray/icon.js
+++ b/src/tray/icon.js
@@ -4,6 +4,35 @@ const getTrayIconPathForMenuBar = ({
   return defaultIconPath
 }
 
+const drawSlashOnBitmap = (bitmap, width, height) => {
+  const inset = Math.max(1, Math.round(width * 0.15))
+  const thickness = Math.max(1, Math.round(width * 0.03))
+  const halfThick = thickness / 2
+  const x0 = inset
+  const y0 = inset
+  const x1 = width - inset
+  const y1 = height - inset
+  const steps = Math.max(width, height) * 2
+  for (let s = 0; s <= steps; s++) {
+    const t = s / steps
+    const cx = x0 + (x1 - x0) * t
+    const cy = y0 + (y1 - y0) * t
+    for (let dy = -halfThick; dy <= halfThick; dy++) {
+      for (let dx = -halfThick; dx <= halfThick; dx++) {
+        const px = Math.round(cx + dx)
+        const py = Math.round(cy + dy)
+        if (px >= 0 && px < width && py >= 0 && py < height) {
+          const idx = (py * width + px) * 4
+          bitmap[idx] = 0
+          bitmap[idx + 1] = 0
+          bitmap[idx + 2] = 0
+          bitmap[idx + 3] = 255
+        }
+      }
+    }
+  }
+}
+
 const createTrayIconFactory = ({
   nativeImage,
   logger = console
@@ -12,13 +41,14 @@ const createTrayIconFactory = ({
 
   return ({
     defaultIconPath,
-    isDarkMode = true
+    isDarkMode = true,
+    isPaused = false
   } = {}) => {
     if (!nativeImage) {
       return null
     }
 
-    const cacheKey = `${defaultIconPath}:${isDarkMode ? 'dark' : 'light'}`
+    const cacheKey = `${defaultIconPath}:${isDarkMode ? 'dark' : 'light'}:${isPaused ? 'paused' : 'active'}`
     if (cache.has(cacheKey)) {
       return cache.get(cacheKey)
     }
@@ -41,7 +71,17 @@ const createTrayIconFactory = ({
       ? trayIconBase.resize({ width: 16, height: 16 })
       : trayIconBase
 
-    const finalIcon = resizedIcon
+    let finalIcon = resizedIcon
+
+    if (isPaused && typeof finalIcon.toBitmap === 'function') {
+      const actualSize = typeof finalIcon.getSize === 'function' ? finalIcon.getSize() : { width: 16, height: 16 }
+      const baseBitmap = finalIcon.toBitmap()
+      const bitmapPx = Math.round(Math.sqrt(baseBitmap.length / 4))
+      const scaleFactor = bitmapPx / actualSize.width
+      const canvas = Buffer.from(baseBitmap)
+      drawSlashOnBitmap(canvas, bitmapPx, bitmapPx)
+      finalIcon = nativeImage.createFromBuffer(canvas, { width: bitmapPx, height: bitmapPx, scaleFactor: scaleFactor || 1 })
+    }
 
     if (typeof finalIcon.setTemplateImage === 'function') {
       finalIcon.setTemplateImage(process.platform === 'darwin')
@@ -54,5 +94,6 @@ const createTrayIconFactory = ({
 
 module.exports = {
   createTrayIconFactory,
+  drawSlashOnBitmap,
   getTrayIconPathForMenuBar
 }

--- a/test/e2e/stills.spec.js
+++ b/test/e2e/stills.spec.js
@@ -597,17 +597,17 @@ test('tray recording action pauses and resumes while settings window reflects st
 
     const initialTrayLabel = await window.evaluate(() => window.familiar.getTrayRecordingLabelForE2E())
     expect(initialTrayLabel.ok).toBe(true)
-    expect(initialTrayLabel.label).toBe('Capturing (click to pause for 10 min)')
+    expect(initialTrayLabel.label).toBe('Capturing')
 
     const pausedTray = await window.evaluate(() => window.familiar.clickTrayRecordingActionForE2E())
     expect(pausedTray.ok).toBe(true)
-    expect(pausedTray.label).toBe('Paused for 10 min (click to resume)')
+    expect(pausedTray.label).toMatch(/^Paused \u2014 (?:9|10):[0-5]\d remaining$/)
 
     await expect(window.locator('#recording-status')).toHaveText('Paused')
 
     const resumedTray = await window.evaluate(() => window.familiar.clickTrayRecordingActionForE2E())
     expect(resumedTray.ok).toBe(true)
-    expect(resumedTray.label).toBe('Capturing (click to pause for 10 min)')
+    expect(resumedTray.label).toBe('Capturing')
 
     await expect(window.locator('#recording-status')).toHaveText('Capturing')
   } finally {

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { buildTrayMenuTemplate } = require('../src/menu');
+const { buildTrayMenuTemplate, PAUSE_DURATIONS, formatPausedLabel } = require('../src/menu');
 const { microcopy } = require('../src/microcopy');
 
 test('buildTrayMenuTemplate returns the expected items', () => {
@@ -30,7 +30,7 @@ test('buildTrayMenuTemplate uses recording label while active', () => {
         recordingState
     });
 
-    const recordingItem = template.find((item) => item.label === microcopy.tray.recording.clickToPauseFor10Min);
+    const recordingItem = template.find((item) => item.label === 'Capturing');
 
     assert.ok(recordingItem);
 });
@@ -104,7 +104,7 @@ test('recording item click does not trigger settings', () => {
     assert.equal(openSettingsCalls, 0);
 });
 
-test('buildTrayMenuTemplate uses minute pause label while paused', () => {
+test('buildTrayMenuTemplate shows paused label with countdown when paused', () => {
     const template = buildTrayMenuTemplate({
         onRecordingPause: () => {},
         onOpenSettings: () => {},
@@ -116,14 +116,11 @@ test('buildTrayMenuTemplate uses minute pause label while paused', () => {
         }
     });
 
-    const recordingItem = template.find(
-        (item) => item.label === microcopy.tray.recording.pausedFor10MinClickToResume
-    );
-
-    assert.ok(recordingItem);
+    assert.ok(template[0].label.includes('remaining'));
+    assert.equal(template[0].toolTip, 'Click to resume');
 });
 
-test('buildTrayMenuTemplate keeps paused label at 1m when remaining time is below one minute', () => {
+test('buildTrayMenuTemplate keeps paused label at fallback when remaining time is zero', () => {
     const template = buildTrayMenuTemplate({
         onRecordingPause: () => {},
         onOpenSettings: () => {},
@@ -136,7 +133,7 @@ test('buildTrayMenuTemplate keeps paused label at 1m when remaining time is belo
     });
 
     const recordingItem = template.find(
-        (item) => item.label === microcopy.tray.recording.pausedFor10MinClickToResume
+        (item) => item.label === 'Paused'
     );
 
     assert.ok(recordingItem);
@@ -152,4 +149,49 @@ test('buildTrayMenuTemplate includes status icon when provided', () => {
     });
 
     assert.equal(template[0].icon, recordingStatusIcon);
+});
+
+test('buildTrayMenuTemplate shows pause duration submenu when recording', () => {
+    const recordingState = { state: 'recording', manualPaused: false };
+    const template = buildTrayMenuTemplate({
+        onRecordingPause: () => {},
+        onOpenSettings: () => {},
+        onQuit: () => {},
+        recordingState
+    });
+
+    const recordingItem = template[0];
+    assert.ok(recordingItem.submenu, 'recording item should have a submenu');
+    assert.equal(recordingItem.submenu.length, PAUSE_DURATIONS.length);
+    assert.equal(recordingItem.submenu[0].label, 'Pause for 5 minutes');
+    assert.equal(recordingItem.submenu[1].label, 'Pause for 10 minutes');
+    assert.equal(recordingItem.submenu[2].label, 'Pause for 30 minutes');
+    assert.equal(recordingItem.submenu[3].label, 'Pause for 1 hour');
+});
+
+test('pause submenu items pass durationMs to onRecordingPause', () => {
+    const pauseCalls = [];
+    const recordingState = { state: 'recording', manualPaused: false };
+    const template = buildTrayMenuTemplate({
+        onRecordingPause: (durationMs) => { pauseCalls.push(durationMs); },
+        onOpenSettings: () => {},
+        onQuit: () => {},
+        recordingState
+    });
+
+    template[0].submenu[0].click();
+    template[0].submenu[1].click();
+
+    assert.deepEqual(pauseCalls, [5 * 60 * 1000, 10 * 60 * 1000]);
+});
+
+test('formatPausedLabel shows countdown when remaining time is positive', () => {
+    const label = formatPausedLabel(125000);
+    assert.ok(label.includes('2:05'));
+    assert.ok(label.includes('remaining'));
+});
+
+test('formatPausedLabel falls back to microcopy when remaining is zero', () => {
+    const label = formatPausedLabel(0);
+    assert.equal(label, 'Paused');
 });

--- a/test/tray-icon.test.js
+++ b/test/tray-icon.test.js
@@ -25,6 +25,9 @@ const createMockImage = ({ empty = false, dataUrl = 'data:image/png;base64,base'
   },
   toDataURL() {
     return dataUrl
+  },
+  toBitmap() {
+    return Buffer.alloc(16 * 16 * 4)
   }
 })
 
@@ -60,4 +63,26 @@ test('createTrayIconFactory keeps normal tray icons as template images', () => {
 
   assert.equal(icon, baseIcon)
   assert.deepEqual(baseIcon.templateCalls, [process.platform === 'darwin'])
+})
+
+test('createTrayIconFactory uses separate cache keys for paused and active', () => {
+  const baseIcon = createMockImage()
+  let createFromPathCalls = 0
+  const nativeImage = {
+    createFromPath: () => { createFromPathCalls++; return createMockImage() },
+    createEmpty: () => createMockImage({ empty: true }),
+    createFromDataURL: () => createMockImage(),
+    createFromBuffer: (buf, size) => createMockImage()
+  }
+  const createTrayIcon = createTrayIconFactory({ nativeImage })
+
+  createTrayIcon({ defaultIconPath, isPaused: false })
+  createTrayIcon({ defaultIconPath, isPaused: true })
+
+  assert.equal(createFromPathCalls, 2, 'should create separate icons for paused and active')
+
+  createTrayIcon({ defaultIconPath, isPaused: false })
+  createTrayIcon({ defaultIconPath, isPaused: true })
+
+  assert.equal(createFromPathCalls, 2, 'should use cache on subsequent calls')
 })

--- a/test/tray-refresh.test.js
+++ b/test/tray-refresh.test.js
@@ -26,12 +26,12 @@ test('tray menu shows recording and paused labels without auto-refresh loop', ()
 
     controller.updateTrayMenu()
     assert.equal(menuCalls.length, 1)
-    assert.equal(menuCalls[0][0].label, microcopy.tray.recording.clickToPauseFor10Min)
+    assert.equal(menuCalls[0][0].label, 'Capturing')
 
     recordingState = { manualPaused: true, state: 'armed', pauseRemainingMs: 61000 }
     controller.updateTrayMenu()
     assert.equal(menuCalls.length, 2)
-    assert.equal(menuCalls[1][0].label, microcopy.tray.recording.pausedFor10MinClickToResume)
+    assert.ok(menuCalls[1][0].label.includes('remaining'), 'paused label should show countdown')
 })
 
 test('registerTrayRefreshHandlers refreshes tray on click and right-click', () => {


### PR DESCRIPTION
- Add diagonal slash overlay on tray icon when capture is paused to help user understand if the app is paused or active
- Replace fixed 10-min pause with submenu: 5m, 10m, 30m, 1hr options
- Show countdown label (Paused — M:SS remaining) in tray menu when paused
- Simplify active label to 'Capturing'
- Add tooltip 'Click to resume' on paused menu item
- Wire icon + menu refresh on recording state transitions
- Accept dynamic durationMs in controller.manualPause()
- Update tests for new menu labels and icon cache keys

Visual changes:

<img width="296" height="162" alt="Screen Shot 2026-04-24 at 09 19 13 AM" src="https://github.com/user-attachments/assets/acfb9082-737f-47b3-a370-0b605649290c" />
<img width="205" height="158" alt="Screen Shot 2026-04-24 at 09 19 48 AM" src="https://github.com/user-attachments/assets/cb9cc7a2-6950-4e39-bd7b-a897b4443440" />
