### PR TITLE
fix: auto-recover stills.db from SQLite corruption, re-enqueue orphan screenshots

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -225,6 +225,27 @@ const attemptScreenCaptureShutdown = (reason) => {
         });
 };
 
+let dbRecoveryToastShownAt = 0;
+const handleStillsDbRecovery = ({ requeuedCount } = {}) => {
+    const now = Date.now();
+    if (now - dbRecoveryToastShownAt < 60000) {
+        console.warn('Stills DB recovery (suppressed duplicate toast)', { requeuedCount });
+        return;
+    }
+    dbRecoveryToastShownAt = now;
+    console.warn('Stills DB recovered from corruption', { requeuedCount });
+    const screenshotWord = requeuedCount === 1 ? 'screenshot is' : 'screenshots are';
+    const body = requeuedCount > 0
+        ? `Familiar reset its screenshot database after detecting corruption. ${requeuedCount} saved ${screenshotWord} being reprocessed.`
+        : 'Familiar reset its screenshot database after detecting corruption. Saved screenshots will be reprocessed if found.';
+    maybeE2EToast({
+        title: 'Screenshot database reset',
+        body,
+        type: 'warning',
+        size: 'large'
+    });
+};
+
 const handleStillsError = ({ message, willRetry, retryDelayMs, attempt } = {}) => {
     if (!message) {
         return;
@@ -809,8 +830,9 @@ if (isPrimaryInstance) {
             }
             screenStillsController = createScreenStillsController({
                 logger: console,
-            onError: handleStillsError,
+                onError: handleStillsError,
                 onRedactionWarning: handleRedactionWarning,
+                onRecovery: handleStillsDbRecovery,
                 onStateTransition: handleRecordingStateTransition,
                 presenceMonitor,
                 ...(pauseDurationOverrideMs ? { pauseDurationMs: pauseDurationOverrideMs } : {})

--- a/src/screen-stills/controller.js
+++ b/src/screen-stills/controller.js
@@ -23,6 +23,7 @@ function createScreenStillsController(options = {}) {
   const onRedactionWarning = typeof options.onRedactionWarning === 'function'
     ? options.onRedactionWarning
     : noop;
+  const onRecovery = typeof options.onRecovery === 'function' ? options.onRecovery : null;
   const onStateTransition = typeof options.onStateTransition === 'function'
     ? options.onStateTransition
     : noop;
@@ -36,9 +37,9 @@ function createScreenStillsController(options = {}) {
   const clock = options.clock || { now: () => Date.now() };
   const presenceMonitor = options.presenceMonitor ||
     createPresenceMonitor({ idleThresholdSeconds, logger });
-  const recorder = options.recorder || createRecorder({ logger });
+  const recorder = options.recorder || createRecorder({ logger, onRecovery });
   const markdownWorker = options.markdownWorker
-    || createStillsMarkdownWorker({ logger, onRedactionWarning });
+    || createStillsMarkdownWorker({ logger, onRedactionWarning, onRecovery });
   const clipboardMirror = options.clipboardMirror
     || ((process.versions && process.versions.electron)
       ? createClipboardMirror({ logger, onRedactionWarning })

--- a/src/screen-stills/recorder.js
+++ b/src/screen-stills/recorder.js
@@ -126,6 +126,7 @@ function createRecorder(options = {}) {
   const lowPowerModeAdaptiveIntervalEnabled = !usesFixedInterval && !hasE2EIntervalOverride;
   const lowPowerModeMonitor = options.lowPowerModeMonitor || createLowPowerModeMonitor({ logger });
   const loadSettingsImpl = options.loadSettingsImpl || loadSettings;
+  const onRecovery = typeof options.onRecovery === 'function' ? options.onRecovery : null;
 
   let captureWindow = null;
   let windowReadyPromise = null;
@@ -914,7 +915,7 @@ function createRecorder(options = {}) {
           contextFolderPath,
           format: CAPTURE_CONFIG.format
         });
-        queueStore = createStillsQueue({ contextFolderPath, logger });
+        queueStore = createStillsQueue({ contextFolderPath, logger, onRecovery });
 
         logger.log('Recording session started', { sessionDir: sessionStore.sessionDir });
 

--- a/src/screen-stills/stills-markdown-worker.js
+++ b/src/screen-stills/stills-markdown-worker.js
@@ -97,7 +97,8 @@ const createStillsMarkdownWorker = ({
   createExtractorImpl = createStillsMarkdownExtractor,
   writeMarkdownFileImpl = writeMarkdownFile,
   scanAndRedactContentImpl = scanAndRedactContent,
-  onRedactionWarning = noop
+  onRedactionWarning = noop,
+  onRecovery = null
 } = {}) => {
   let running = false
   let contextFolderPath = ''
@@ -126,7 +127,7 @@ const createStillsMarkdownWorker = ({
     }
     stop()
     contextFolderPath = nextContextFolderPath
-    queueStore = createQueueImpl({ contextFolderPath, logger })
+    queueStore = createQueueImpl({ contextFolderPath, logger, onRecovery })
     running = true
     if (Number.isFinite(pollIntervalMs) && pollIntervalMs > 0) {
       timer = setInterval(() => {

--- a/src/screen-stills/stills-queue.js
+++ b/src/screen-stills/stills-queue.js
@@ -3,6 +3,7 @@ const path = require('node:path')
 const Database = require('better-sqlite3')
 const { FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_DB_FILENAME } = require('../const')
 const { normalizeAppString } = require('../utils/strings')
+const { scanOrphanStills } = require('./stills-recovery')
 
 const STATUS = Object.freeze({
   PENDING: 'pending',
@@ -26,7 +27,36 @@ const normalizeVisibleWindowNames = (visibleWindowNames) => {
   return null
 }
 
-const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
+/**
+ * Returns true when the error indicates SQLite file-level corruption.
+ * Covers the SQLITE_CORRUPT and SQLITE_NOTADB error codes as well as the
+ * "database disk image is malformed" message that appears in some versions.
+ */
+const isCorruptionError = (err) => {
+  if (!err) return false
+  if (err.code === 'SQLITE_CORRUPT' || err.code === 'SQLITE_NOTADB') return true
+  const msg = typeof err.message === 'string' ? err.message.toLowerCase() : ''
+  return (
+    msg.includes('database disk image is malformed') ||
+    msg.includes('file is not a database')
+  )
+}
+
+/**
+ * Rename stills.db to stills.db.corrupt-<timestamp> and delete any leftover
+ * WAL/SHM sidecar files.  Returns the quarantine path.
+ */
+const quarantineDbFiles = (dbPath) => {
+  const suffix = new Date().toISOString().replace(/[:.]/g, '-')
+  const quarantinePath = `${dbPath}.corrupt-${suffix}`
+  try { fs.renameSync(dbPath, quarantinePath) } catch (_) {}
+  for (const ext of ['-wal', '-shm']) {
+    try { fs.unlinkSync(`${dbPath}${ext}`) } catch (_) {}
+  }
+  return quarantinePath
+}
+
+const createStillsQueue = ({ contextFolderPath, logger = console, onRecovery = null } = {}) => {
   if (!contextFolderPath) {
     throw new Error('Context folder path is required for stills queue.')
   }
@@ -34,136 +64,277 @@ const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
   const dbPath = resolveDbPath(contextFolderPath)
   fs.mkdirSync(path.dirname(dbPath), { recursive: true })
 
-  const db = new Database(dbPath)
-  db.pragma('journal_mode = WAL')
+  // Mutable DB handle and prepared statements — replaced on recovery
+  let db = null
+  let stmts = {}
+  let recovering = false
 
-  const existingColumns = [];
-  const ensureColumn = (name, ddl) => {
-    if (existingColumns.includes(name)) {
-      return;
-    }
-    db.exec(`ALTER TABLE stills_queue ADD COLUMN ${ddl}`)
-    existingColumns.push(name)
+  const openDb = () => {
+    db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
   }
 
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS stills_queue (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      image_path TEXT UNIQUE NOT NULL,
-      session_id TEXT NOT NULL,
-      captured_at TEXT NOT NULL,
-      status TEXT NOT NULL,
-      provider TEXT,
-      model TEXT,
-      markdown_path TEXT,
-      last_error TEXT,
-      app_name TEXT,
-      app_bundle_id TEXT,
-      app_title TEXT,
-      app_label_source TEXT,
-      visible_window_names TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-    CREATE INDEX IF NOT EXISTS idx_stills_queue_status_captured
-      ON stills_queue (status, captured_at);
-  `)
-  const tableInfo = db.prepare('PRAGMA table_info(stills_queue)').all()
-  existingColumns.push(
-    ...Array.isArray(tableInfo) ? tableInfo.map((row) => row?.name).filter(Boolean) : []
-  )
-
-  ensureColumn('app_name', 'app_name TEXT')
-  ensureColumn('app_bundle_id', 'app_bundle_id TEXT')
-  ensureColumn('app_title', 'app_title TEXT')
-  ensureColumn('app_label_source', 'app_label_source TEXT')
-  ensureColumn('visible_window_names', 'visible_window_names TEXT')
-
-  logger.log('Stills queue initialized', { dbPath })
-
-  const insertStmt = db.prepare(`
-    INSERT OR IGNORE INTO stills_queue (
-      image_path,
-      session_id,
-      captured_at,
-      status,
-      provider,
-      model,
-      markdown_path,
-      last_error,
-      app_name,
-      app_bundle_id,
-      app_title,
-      app_label_source,
-      visible_window_names,
-      created_at,
-      updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `)
-
-  const pendingStmt = db.prepare(`
-    SELECT
-      id,
-      image_path,
-      session_id,
-      captured_at,
-      app_name,
-      app_bundle_id,
-      app_title,
-      app_label_source,
-      visible_window_names
-    FROM stills_queue
-    WHERE status = ?
-    ORDER BY captured_at ASC
-    LIMIT ?
-  `)
-
-  const updateStatusStmt = db.prepare(`
-    UPDATE stills_queue
-    SET status = ?, updated_at = ?
-    WHERE id = ?
-  `)
-
-  const updateProcessingStmt = (ids) => {
-    if (!Array.isArray(ids) || ids.length === 0) {
-      return null
+  const initSchema = () => {
+    const existingColumns = []
+    const ensureColumn = (name, ddl) => {
+      if (existingColumns.includes(name)) return
+      db.exec(`ALTER TABLE stills_queue ADD COLUMN ${ddl}`)
+      existingColumns.push(name)
     }
-    const placeholders = ids.map(() => '?').join(', ')
-    return db.prepare(`
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS stills_queue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        image_path TEXT UNIQUE NOT NULL,
+        session_id TEXT NOT NULL,
+        captured_at TEXT NOT NULL,
+        status TEXT NOT NULL,
+        provider TEXT,
+        model TEXT,
+        markdown_path TEXT,
+        last_error TEXT,
+        app_name TEXT,
+        app_bundle_id TEXT,
+        app_title TEXT,
+        app_label_source TEXT,
+        visible_window_names TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_stills_queue_status_captured
+        ON stills_queue (status, captured_at);
+    `)
+    const tableInfo = db.prepare('PRAGMA table_info(stills_queue)').all()
+    existingColumns.push(
+      ...Array.isArray(tableInfo) ? tableInfo.map((row) => row?.name).filter(Boolean) : []
+    )
+
+    ensureColumn('app_name', 'app_name TEXT')
+    ensureColumn('app_bundle_id', 'app_bundle_id TEXT')
+    ensureColumn('app_title', 'app_title TEXT')
+    ensureColumn('app_label_source', 'app_label_source TEXT')
+    ensureColumn('visible_window_names', 'visible_window_names TEXT')
+  }
+
+  const prepareStatements = () => {
+    stmts.insert = db.prepare(`
+      INSERT OR IGNORE INTO stills_queue (
+        image_path,
+        session_id,
+        captured_at,
+        status,
+        provider,
+        model,
+        markdown_path,
+        last_error,
+        app_name,
+        app_bundle_id,
+        app_title,
+        app_label_source,
+        visible_window_names,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+
+    stmts.pending = db.prepare(`
+      SELECT
+        id,
+        image_path,
+        session_id,
+        captured_at,
+        app_name,
+        app_bundle_id,
+        app_title,
+        app_label_source,
+        visible_window_names
+      FROM stills_queue
+      WHERE status = ?
+      ORDER BY captured_at ASC
+      LIMIT ?
+    `)
+
+    stmts.updateStatus = db.prepare(`
       UPDATE stills_queue
       SET status = ?, updated_at = ?
-      WHERE status = ? AND id IN (${placeholders})
+      WHERE id = ?
+    `)
+
+    stmts.updateDone = db.prepare(`
+      UPDATE stills_queue
+      SET status = ?,
+          markdown_path = ?,
+          provider = ?,
+          model = ?,
+          last_error = NULL,
+          updated_at = ?
+      WHERE id = ?
+    `)
+
+    stmts.updateFailed = db.prepare(`
+      UPDATE stills_queue
+      SET status = ?, last_error = ?, updated_at = ?
+      WHERE id = ?
+    `)
+
+    stmts.updatePendingWithError = db.prepare(`
+      UPDATE stills_queue
+      SET status = ?, last_error = ?, updated_at = ?
+      WHERE id = ?
+    `)
+
+    stmts.updateStaleProcessing = db.prepare(`
+      UPDATE stills_queue
+      SET status = ?, updated_at = ?
+      WHERE status = ? AND updated_at < ?
     `)
   }
 
-  const updateDoneStmt = db.prepare(`
-    UPDATE stills_queue
-    SET status = ?,
-        markdown_path = ?,
-        provider = ?,
-        model = ?,
-        last_error = NULL,
-        updated_at = ?
-    WHERE id = ?
-  `)
+  const initDb = () => {
+    openDb()
+    initSchema()
+    prepareStatements()
+  }
 
-  const updateFailedStmt = db.prepare(`
-    UPDATE stills_queue
-    SET status = ?, last_error = ?, updated_at = ?
-    WHERE id = ?
-  `)
+  /**
+   * Open a read-only probe connection to check whether the on-disk stills.db
+   * is healthy.  If it is, return null (no quarantine needed — another
+   * connection already replaced the file).  If it is corrupt, quarantine it
+   * and return the quarantine path.
+   */
+  const checkAndMaybeQuarantine = () => {
+    let shouldQuarantine = true
+    try {
+      const probe = new Database(dbPath, { readonly: true })
+      const result = probe.pragma('integrity_check')
+      const ok = Array.isArray(result) && result.length === 1 && result[0]?.integrity_check === 'ok'
+      probe.close()
+      shouldQuarantine = !ok
+    } catch (_) {
+      // Probe failed — file is still corrupt or missing
+      shouldQuarantine = true
+    }
+    if (!shouldQuarantine) return null
+    return quarantineDbFiles(dbPath)
+  }
 
-  const updatePendingWithErrorStmt = db.prepare(`
-    UPDATE stills_queue
-    SET status = ?, last_error = ?, updated_at = ?
-    WHERE id = ?
-  `)
+  const enqueueOrphans = () => {
+    let requeuedCount = 0
+    try {
+      const orphans = scanOrphanStills({ contextFolderPath, logger })
+      for (const orphan of orphans) {
+        try {
+          const now = new Date().toISOString()
+          const info = stmts.insert.run(
+            orphan.imagePath,
+            orphan.sessionId,
+            orphan.capturedAt,
+            STATUS.PENDING,
+            null, null, null, null,
+            null, null, null, null, null,
+            now, now
+          )
+          if (info.changes > 0) requeuedCount++
+        } catch (enqueueErr) {
+          logger.error('Failed to requeue orphan still after DB recovery', {
+            imagePath: orphan.imagePath,
+            error: enqueueErr?.message || String(enqueueErr)
+          })
+        }
+      }
+    } catch (scanErr) {
+      logger.error('Failed to scan orphan stills after DB recovery', {
+        error: scanErr?.message || String(scanErr)
+      })
+    }
+    return requeuedCount
+  }
 
-  const updateStaleProcessingStmt = db.prepare(`
-    UPDATE stills_queue
-    SET status = ?, updated_at = ?
-    WHERE status = ? AND updated_at < ?
-  `)
+  /**
+   * Internal recovery routine called on startup corruption or mid-session
+   * SQLITE_CORRUPT errors.  Closes the current connection, checks whether the
+   * DB file is still corrupt, quarantines it if so, opens a fresh database,
+   * re-enqueues orphan screenshots, and fires the onRecovery callback.
+   * Returns true on success; false if recovery itself fails.
+   */
+  const recover = (reason) => {
+    if (recovering) return false
+    recovering = true
+    try {
+      logger.error('stills.db corruption detected, attempting recovery', { dbPath, reason })
+      try { if (db) db.close() } catch (_) {}
+      db = null
+
+      const quarantinePath = checkAndMaybeQuarantine()
+
+      initDb()
+
+      if (quarantinePath !== null) {
+        const requeuedCount = enqueueOrphans()
+        logger.log('stills.db recovery complete', { quarantinePath, requeuedCount })
+        if (typeof onRecovery === 'function') {
+          try { onRecovery({ dbPath, quarantinePath, requeuedCount }) } catch (_) {}
+        }
+      } else {
+        // DB was already healthy — another connection recovered it; just reconnected
+        logger.log('stills.db reconnected after corruption (DB already healthy)', { dbPath })
+      }
+      return true
+    } catch (err) {
+      logger.error('stills.db recovery failed', { error: err?.message || String(err) })
+      return false
+    } finally {
+      recovering = false
+    }
+  }
+
+  /**
+   * Execute fn(), catch SQLITE_CORRUPT, attempt one recovery, then retry.
+   * If recovery itself fails the original error is re-thrown.
+   */
+  const withCorruptionRetry = (fn) => {
+    try {
+      return fn()
+    } catch (err) {
+      if (!isCorruptionError(err)) throw err
+      if (!recover('runtime-operation')) throw err
+      return fn()
+    }
+  }
+
+  // --- Startup: open and run integrity check before any schema work ---
+  // Both new Database() and the integrity pragma can throw SQLITE_NOTADB /
+  // SQLITE_CORRUPT when the file is malformed, so wrap them together.
+
+  let startupCorrupt = false
+  try {
+    openDb()
+    const result = db.pragma('integrity_check')
+    const ok = Array.isArray(result) && result.length === 1 && result[0]?.integrity_check === 'ok'
+    if (!ok) startupCorrupt = true
+  } catch (err) {
+    if (isCorruptionError(err)) {
+      // Close the partially-opened handle if one exists
+      try { if (db) db.close() } catch (_) {}
+      db = null
+      startupCorrupt = true
+    } else {
+      throw err
+    }
+  }
+
+  if (startupCorrupt) {
+    // recover() closes db (handling null safely), quarantines, re-opens,
+    // scans orphans, fires callback
+    recover('startup-integrity-check')
+  } else {
+    initSchema()
+    prepareStatements()
+  }
+
+  logger.log('Stills queue initialized', { dbPath })
+
+  // --- Public API ---
 
   const enqueueCapture = ({
     imagePath,
@@ -187,48 +358,53 @@ const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
       throw new Error('capturedAt is required to enqueue still capture.')
     }
 
-    const now = new Date().toISOString()
-    const info = insertStmt.run(
-      imagePath,
-      sessionId,
-      capturedAt,
-      STATUS.PENDING,
-      provider || null,
-      model || null,
-      null,
-      null,
-      appName || null,
-      appBundleId || null,
-      appTitle || null,
-      appLabelSource || null,
-      normalizeVisibleWindowNames(visibleWindowNames),
-      now,
-      now
-    )
+    return withCorruptionRetry(() => {
+      const now = new Date().toISOString()
+      const info = stmts.insert.run(
+        imagePath,
+        sessionId,
+        capturedAt,
+        STATUS.PENDING,
+        provider || null,
+        model || null,
+        null,
+        null,
+        appName || null,
+        appBundleId || null,
+        appTitle || null,
+        appLabelSource || null,
+        normalizeVisibleWindowNames(visibleWindowNames),
+        now,
+        now
+      )
 
-    if (info.changes > 0) {
-      logger.log('Enqueued still capture', { imagePath, sessionId, capturedAt })
-    }
+      if (info.changes > 0) {
+        logger.log('Enqueued still capture', { imagePath, sessionId, capturedAt })
+      }
 
-    return info.changes > 0
+      return info.changes > 0
+    })
   }
 
   const getPendingBatch = (limit = 30) => {
     const resolvedLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 30
-    return pendingStmt.all(STATUS.PENDING, resolvedLimit)
+    return withCorruptionRetry(() => stmts.pending.all(STATUS.PENDING, resolvedLimit))
   }
 
   const markProcessing = (ids) => {
     if (!Array.isArray(ids) || ids.length === 0) {
       return 0
     }
-    const stmt = updateProcessingStmt(ids)
-    if (!stmt) {
-      return 0
-    }
-    const now = new Date().toISOString()
-    const info = stmt.run(STATUS.PROCESSING, now, STATUS.PENDING, ...ids)
-    return info.changes
+    return withCorruptionRetry(() => {
+      const placeholders = ids.map(() => '?').join(', ')
+      const stmt = db.prepare(`
+        UPDATE stills_queue
+        SET status = ?, updated_at = ?
+        WHERE status = ? AND id IN (${placeholders})
+      `)
+      const now = new Date().toISOString()
+      return stmt.run(STATUS.PROCESSING, now, STATUS.PENDING, ...ids).changes
+    })
   }
 
   const markDone = ({ id, markdownPath, provider, model } = {}) => {
@@ -238,36 +414,39 @@ const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
     if (!markdownPath) {
       throw new Error('markdownPath is required to mark still as done.')
     }
-    const now = new Date().toISOString()
-    const info = updateDoneStmt.run(
-      STATUS.DONE,
-      markdownPath,
-      provider || null,
-      model || null,
-      now,
-      id
-    )
-    return info.changes
+    return withCorruptionRetry(() => {
+      const now = new Date().toISOString()
+      return stmts.updateDone.run(
+        STATUS.DONE,
+        markdownPath,
+        provider || null,
+        model || null,
+        now,
+        id
+      ).changes
+    })
   }
 
   const markFailed = ({ id, error } = {}) => {
     if (!id) {
       throw new Error('id is required to mark still as failed.')
     }
-    const now = new Date().toISOString()
-    const message = error ? String(error) : 'unknown error'
-    const info = updateFailedStmt.run(STATUS.FAILED, message, now, id)
-    return info.changes
+    return withCorruptionRetry(() => {
+      const now = new Date().toISOString()
+      const message = error ? String(error) : 'unknown error'
+      return stmts.updateFailed.run(STATUS.FAILED, message, now, id).changes
+    })
   }
 
   const markPending = ({ id, error } = {}) => {
     if (!id) {
       throw new Error('id is required to requeue a still.')
     }
-    const now = new Date().toISOString()
-    const message = error ? String(error) : null
-    const info = updatePendingWithErrorStmt.run(STATUS.PENDING, message, now, id)
-    return info.changes
+    return withCorruptionRetry(() => {
+      const now = new Date().toISOString()
+      const message = error ? String(error) : null
+      return stmts.updatePendingWithError.run(STATUS.PENDING, message, now, id).changes
+    })
   }
 
   const requeueStaleProcessing = ({ olderThanMs } = {}) => {
@@ -277,15 +456,16 @@ const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
     if (!resolvedOlderThanMs) {
       return 0
     }
-    const cutoff = new Date(Date.now() - resolvedOlderThanMs).toISOString()
-    const now = new Date().toISOString()
-    const info = updateStaleProcessingStmt.run(
-      STATUS.PENDING,
-      now,
-      STATUS.PROCESSING,
-      cutoff
-    )
-    return info.changes
+    return withCorruptionRetry(() => {
+      const cutoff = new Date(Date.now() - resolvedOlderThanMs).toISOString()
+      const now = new Date().toISOString()
+      return stmts.updateStaleProcessing.run(
+        STATUS.PENDING,
+        now,
+        STATUS.PROCESSING,
+        cutoff
+      ).changes
+    })
   }
 
   const close = () => {
@@ -309,5 +489,6 @@ const createStillsQueue = ({ contextFolderPath, logger = console } = {}) => {
 module.exports = {
   STATUS,
   resolveDbPath,
+  isCorruptionError,
   createStillsQueue
 }

--- a/src/screen-stills/stills-recovery.js
+++ b/src/screen-stills/stills-recovery.js
@@ -1,0 +1,88 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  FAMILIAR_BEHIND_THE_SCENES_DIR_NAME,
+  STILLS_DIR_NAME,
+  STILLS_MARKDOWN_DIR_NAME
+} = require('../const')
+const { parseTimestampMs } = require('../utils/timestamp-utils')
+
+/**
+ * Scan the stills filesystem and return entries for every .webp capture that
+ * has no corresponding .md file in stills-markdown.  These are screenshots
+ * that were captured while the SQLite queue was broken and can be re-enqueued
+ * for OCR after the database is replaced.
+ *
+ * @param {{ contextFolderPath: string, logger?: object }} options
+ * @returns {Array<{ imagePath: string, sessionId: string, capturedAt: string }>}
+ */
+const scanOrphanStills = ({ contextFolderPath, logger = console } = {}) => {
+  if (!contextFolderPath) return []
+
+  const stillsRoot = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_DIR_NAME)
+  const markdownRoot = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_MARKDOWN_DIR_NAME)
+
+  let sessionNames
+  try {
+    sessionNames = fs.readdirSync(stillsRoot).filter((name) => {
+      if (!name.startsWith('session-')) return false
+      try {
+        return fs.statSync(path.join(stillsRoot, name)).isDirectory()
+      } catch (_) {
+        return false
+      }
+    })
+  } catch (_) {
+    // stills directory doesn't exist yet — nothing to recover
+    return []
+  }
+
+  const orphans = []
+
+  for (const sessionId of sessionNames) {
+    const sessionDir = path.join(stillsRoot, sessionId)
+    let files
+    try {
+      files = fs.readdirSync(sessionDir).filter((f) => f.endsWith('.webp'))
+    } catch (e) {
+      if (typeof logger.warn === 'function') {
+        logger.warn('Could not read stills session directory during orphan scan', {
+          sessionDir,
+          error: e?.message || String(e)
+        })
+      }
+      continue
+    }
+
+    for (const fileName of files) {
+      const imagePath = path.join(sessionDir, fileName)
+      const baseName = path.basename(fileName, '.webp')
+      const markdownPath = path.join(markdownRoot, sessionId, `${baseName}.md`)
+
+      try {
+        if (fs.existsSync(markdownPath)) continue
+      } catch (_) {
+        // If we cannot stat the markdown path, treat the still as orphaned
+      }
+
+      let capturedAt
+      const parsedMs = parseTimestampMs(baseName)
+      if (parsedMs !== null) {
+        capturedAt = new Date(parsedMs).toISOString()
+      } else {
+        try {
+          capturedAt = fs.statSync(imagePath).mtime.toISOString()
+        } catch (_) {
+          capturedAt = new Date().toISOString()
+        }
+      }
+
+      orphans.push({ imagePath, sessionId, capturedAt })
+    }
+  }
+
+  return orphans
+}
+
+module.exports = { scanOrphanStills }

--- a/src/skills/familiar/SKILL.md
+++ b/src/skills/familiar/SKILL.md
@@ -89,3 +89,7 @@ Clipboard captures are stored alongside screen captures as `<captureTimestamp>.c
 - Do not infer text that is not explicitly present.
 - Treat `UNCLEAR` and `unknown` as missing data.
 - Avoid scanning the entire history unless the user explicitly requests it.
+
+## Troubleshooting
+
+If screenshots exist under `familiar/stills` but OCR markdown is missing under `familiar/stills-markdown`, the SQLite queue may have been corrupted. Restart Familiar and check the app log for `SQLITE_CORRUPT`. Newer builds automatically reset a corrupted stills database on startup and re-enqueue saved screenshots for reprocessing.

--- a/test/stills-queue.test.js
+++ b/test/stills-queue.test.js
@@ -6,6 +6,7 @@ const path = require('node:path')
 const Database = require('better-sqlite3')
 
 const { createStillsQueue, resolveDbPath } = require('../src/screen-stills/stills-queue')
+const { FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_DIR_NAME, STILLS_MARKDOWN_DIR_NAME } = require('../src/const')
 
 const makeTempContext = () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'familiar-stills-queue-'))
@@ -227,4 +228,106 @@ test('stills queue migrates legacy schema and exposes app metadata columns', () 
   db.close()
 
   queue.close()
+})
+
+test('stills queue auto-recovers when database file is corrupt at startup', () => {
+  const contextFolderPath = makeTempContext()
+  const dbPath = resolveDbPath(contextFolderPath)
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+
+  // Write garbage bytes so SQLite cannot parse it
+  fs.writeFileSync(dbPath, Buffer.from('this is not a valid sqlite database file'))
+
+  const recoveryEvents = []
+  const queue = createStillsQueue({
+    contextFolderPath,
+    logger: { log: () => {}, warn: () => {}, error: () => {} },
+    onRecovery: (event) => recoveryEvents.push(event)
+  })
+
+  // Recovery should have fired with the quarantine path
+  assert.equal(recoveryEvents.length, 1)
+  assert.ok(typeof recoveryEvents[0].quarantinePath === 'string')
+  assert.ok(recoveryEvents[0].quarantinePath.includes('.corrupt-'))
+
+  // The quarantined file should exist on disk
+  assert.ok(fs.existsSync(recoveryEvents[0].quarantinePath))
+
+  // The queue should be fully operational after recovery
+  const imagePath = path.join(contextFolderPath, 'familiar', 'stills', 'session-r', 'frame.webp')
+  const inserted = queue.enqueueCapture({ imagePath, sessionId: 'session-r', capturedAt: new Date().toISOString() })
+  assert.equal(inserted, true)
+
+  const batch = queue.getPendingBatch(10)
+  assert.equal(batch.length, 1)
+  assert.equal(batch[0].image_path, imagePath)
+
+  queue.close()
+})
+
+test('stills queue startup recovery requeues orphan screenshots without matching markdown', () => {
+  const contextFolderPath = makeTempContext()
+
+  // Create two .webp stills; one has a matching .md, one does not
+  const sessionId = 'session-orphan'
+  const stillsDir = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_DIR_NAME, sessionId)
+  const markdownDir = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_MARKDOWN_DIR_NAME, sessionId)
+
+  fs.mkdirSync(stillsDir, { recursive: true })
+  fs.mkdirSync(markdownDir, { recursive: true })
+
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-00-000.webp'), 'fake-image')
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-05-000.webp'), 'fake-image')
+  // Only the first still has a matching markdown — the second is an orphan
+  fs.writeFileSync(path.join(markdownDir, '2026-01-01T10-00-00-000.md'), '# OCR\n- "hello"')
+
+  // Corrupt the DB so recovery runs
+  const dbPath = resolveDbPath(contextFolderPath)
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true })
+  fs.writeFileSync(dbPath, Buffer.from('not a database'))
+
+  const queue = createStillsQueue({
+    contextFolderPath,
+    logger: { log: () => {}, warn: () => {}, error: () => {} },
+    onRecovery: () => {}
+  })
+
+  const batch = queue.getPendingBatch(10)
+  const paths = batch.map((r) => r.image_path)
+
+  // Only the orphan (without a .md) should be requeued
+  assert.equal(batch.length, 1)
+  assert.ok(paths[0].includes('2026-01-01T10-00-05-000.webp'))
+
+  queue.close()
+})
+
+test('stills queue does not quarantine a fresh database when probe shows it is healthy', () => {
+  const contextFolderPath = makeTempContext()
+
+  // Open a queue normally — DB is created fresh and healthy
+  const firstQueue = createStillsQueue({
+    contextFolderPath,
+    logger: { log: () => {}, warn: () => {}, error: () => {} }
+  })
+
+  const imagePath = path.join(contextFolderPath, 'familiar', 'stills', 'session-h', 'frame.webp')
+  firstQueue.enqueueCapture({ imagePath, sessionId: 'session-h', capturedAt: new Date().toISOString() })
+  firstQueue.close()
+
+  // Open a second queue on the same healthy DB — onRecovery must not fire
+  const recoveryEvents = []
+  const secondQueue = createStillsQueue({
+    contextFolderPath,
+    logger: { log: () => {}, warn: () => {}, error: () => {} },
+    onRecovery: (event) => recoveryEvents.push(event)
+  })
+
+  assert.equal(recoveryEvents.length, 0)
+
+  const batch = secondQueue.getPendingBatch(10)
+  assert.equal(batch.length, 1)
+  assert.equal(batch[0].image_path, imagePath)
+
+  secondQueue.close()
 })

--- a/test/stills-recovery.test.js
+++ b/test/stills-recovery.test.js
@@ -1,0 +1,148 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { scanOrphanStills } = require('../src/screen-stills/stills-recovery')
+const {
+  FAMILIAR_BEHIND_THE_SCENES_DIR_NAME,
+  STILLS_DIR_NAME,
+  STILLS_MARKDOWN_DIR_NAME
+} = require('../src/const')
+
+const makeTempContext = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'familiar-stills-recovery-'))
+  fs.mkdirSync(root, { recursive: true })
+  return root
+}
+
+const makeStillsDir = (contextFolderPath, sessionId) => {
+  const dir = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_DIR_NAME, sessionId)
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+const makeMarkdownDir = (contextFolderPath, sessionId) => {
+  const dir = path.join(contextFolderPath, FAMILIAR_BEHIND_THE_SCENES_DIR_NAME, STILLS_MARKDOWN_DIR_NAME, sessionId)
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+test('scanOrphanStills returns empty array when stills directory does not exist', () => {
+  const contextFolderPath = makeTempContext()
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+  assert.deepEqual(orphans, [])
+})
+
+test('scanOrphanStills returns empty array when there are no .webp files', () => {
+  const contextFolderPath = makeTempContext()
+  makeStillsDir(contextFolderPath, 'session-empty')
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+  assert.deepEqual(orphans, [])
+})
+
+test('scanOrphanStills returns all webp files when no markdown directory exists', () => {
+  const contextFolderPath = makeTempContext()
+  const sessionId = 'session-nomd'
+  const stillsDir = makeStillsDir(contextFolderPath, sessionId)
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-00-000.webp'), 'img')
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-05-000.webp'), 'img')
+
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+
+  assert.equal(orphans.length, 2)
+  assert.ok(orphans.every((o) => o.sessionId === sessionId))
+  assert.ok(orphans.every((o) => o.imagePath.endsWith('.webp')))
+})
+
+test('scanOrphanStills returns only webp files without a matching markdown', () => {
+  const contextFolderPath = makeTempContext()
+  const sessionId = 'session-mixed'
+  const stillsDir = makeStillsDir(contextFolderPath, sessionId)
+  const markdownDir = makeMarkdownDir(contextFolderPath, sessionId)
+
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-00-000.webp'), 'img')
+  fs.writeFileSync(path.join(stillsDir, '2026-01-01T10-00-05-000.webp'), 'img')
+  // First still has a markdown; second does not
+  fs.writeFileSync(path.join(markdownDir, '2026-01-01T10-00-00-000.md'), '# OCR')
+
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+
+  assert.equal(orphans.length, 1)
+  assert.ok(orphans[0].imagePath.includes('2026-01-01T10-00-05-000.webp'))
+  assert.equal(orphans[0].sessionId, sessionId)
+})
+
+test('scanOrphanStills parses capturedAt from the capture filename', () => {
+  const contextFolderPath = makeTempContext()
+  const sessionId = 'session-ts'
+  const stillsDir = makeStillsDir(contextFolderPath, sessionId)
+  fs.writeFileSync(path.join(stillsDir, '2026-03-15T09-30-45-123.webp'), 'img')
+
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+
+  assert.equal(orphans.length, 1)
+  // The parsed ISO string should represent the local time encoded in the filename
+  assert.ok(typeof orphans[0].capturedAt === 'string')
+  assert.ok(orphans[0].capturedAt.length > 0)
+  // Verify it parses as a valid date
+  assert.ok(!Number.isNaN(Date.parse(orphans[0].capturedAt)))
+})
+
+test('scanOrphanStills falls back to file mtime when filename is not a parseable timestamp', () => {
+  const contextFolderPath = makeTempContext()
+  const sessionId = 'session-mtime'
+  const stillsDir = makeStillsDir(contextFolderPath, sessionId)
+  const weirdPath = path.join(stillsDir, 'not-a-timestamp.webp')
+  fs.writeFileSync(weirdPath, 'img')
+
+  const beforeMs = Date.now()
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+  const afterMs = Date.now()
+
+  assert.equal(orphans.length, 1)
+  const parsedMs = Date.parse(orphans[0].capturedAt)
+  // capturedAt should be approximately the mtime (within a wide window)
+  assert.ok(!Number.isNaN(parsedMs))
+  assert.ok(parsedMs >= beforeMs - 5000 && parsedMs <= afterMs + 5000)
+})
+
+test('scanOrphanStills skips non-session directories and non-webp files', () => {
+  const contextFolderPath = makeTempContext()
+  const stillsRoot = path.join(
+    contextFolderPath,
+    FAMILIAR_BEHIND_THE_SCENES_DIR_NAME,
+    STILLS_DIR_NAME
+  )
+  fs.mkdirSync(stillsRoot, { recursive: true })
+
+  // A directory without the session- prefix should be ignored
+  const notASession = path.join(stillsRoot, 'random-dir')
+  fs.mkdirSync(notASession)
+  fs.writeFileSync(path.join(notASession, 'frame.webp'), 'img')
+
+  // A valid session dir with a non-webp file should produce no orphans
+  const sessionDir = path.join(stillsRoot, 'session-skip')
+  fs.mkdirSync(sessionDir)
+  fs.writeFileSync(path.join(sessionDir, 'readme.txt'), 'text')
+
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+  assert.deepEqual(orphans, [])
+})
+
+test('scanOrphanStills returns empty array when all webp files have matching markdown', () => {
+  const contextFolderPath = makeTempContext()
+  const sessionId = 'session-complete'
+  const stillsDir = makeStillsDir(contextFolderPath, sessionId)
+  const markdownDir = makeMarkdownDir(contextFolderPath, sessionId)
+
+  for (let i = 0; i < 3; i++) {
+    const base = `2026-01-01T10-00-0${i}-000`
+    fs.writeFileSync(path.join(stillsDir, `${base}.webp`), 'img')
+    fs.writeFileSync(path.join(markdownDir, `${base}.md`), '# OCR')
+  }
+
+  const orphans = scanOrphanStills({ contextFolderPath, logger: { warn: () => {} } })
+  assert.deepEqual(orphans, [])
+})


### PR DESCRIPTION
## Problem

When `stills.db` becomes corrupt (observed as `SQLITE_CORRUPT: database disk image is malformed`), the app continues capturing screenshots to disk but silently fails to enqueue them for OCR. Every call to `enqueueCapture()` or `getPendingBatch()` throws, gets caught and logged, and the loop continues. The UI shows "recording normally". No `.md` transcripts are produced. The user has no indication anything is wrong.

Root cause is in `src/screen-stills/stills-queue.js`: there is no integrity check on open, and runtime corruption errors are not recovered from — they just accumulate silently in the logs.

## Fix

### Startup integrity check (`stills-queue.js`)

`createStillsQueue()` now wraps `new Database()` and `PRAGMA integrity_check` in the same try/catch **before any schema work**. If either throws `SQLITE_CORRUPT` / `SQLITE_NOTADB`, or if the integrity result is not `"ok"`, the bad file is quarantined:

```
stills.db  →  stills.db.corrupt-2026-05-04T18-30-00-000Z
stills.db-wal  (deleted)
stills.db-shm  (deleted)
```

A fresh, empty database is created in its place and normal startup proceeds.

### Runtime corruption retry (`stills-queue.js`)

All public queue methods are wrapped with `withCorruptionRetry()`. On the first `SQLITE_CORRUPT` thrown mid-session the queue:

1. Closes its own connection.
2. Opens a read-only probe on the current `stills.db` to check if it is still corrupt.
3. Quarantines it **only if still corrupt** — skips quarantine if a second connection (the markdown worker or the recorder) already replaced the file, to avoid double-quarantine races.
4. Opens a fresh database, rebuilds all prepared statements.
5. Retries the failed operation once.

### Orphan re-enqueue (`stills-recovery.js`, new)

After any quarantine the queue calls `scanOrphanStills()`, which walks `stills/session-*/*.webp` and returns every capture without a matching `.md` in `stills-markdown/`. These screenshots were captured while the queue was broken. Each is inserted as `pending` via `INSERT OR IGNORE`, so the scan is idempotent.

`capturedAt` is parsed from the filename using the existing `parseTimestampMs()` helper; file mtime is the fallback for non-standard names.

### User notification (`main.js`, `controller.js`, `recorder.js`, `stills-markdown-worker.js`)

An `onRecovery` callback option is threaded from `createStillsQueue()` up through the recorder, markdown worker, and controller to `main.js`, where it shows a non-blocking warning toast:

> **Screenshot database reset**
> Familiar reset its screenshot database after detecting corruption. N saved screenshots are being reprocessed.

A 60-second dedup guard prevents the toast from appearing twice when both the recorder and the worker detect the same corruption event in quick succession.

## Testing

Three new tests in `test/stills-queue.test.js`:

- Corrupt file at startup: garbage bytes → queue opens, `onRecovery` fires, quarantine file exists on disk, queue is fully operational.
- Orphan requeue: two `.webp` stills, one with a `.md` and one without → after corruption recovery only the orphan is pending.
- No double-quarantine: healthy DB opened twice → `onRecovery` never fires.

Seven new tests in `test/stills-recovery.test.js` covering all `scanOrphanStills()` paths (missing dir, empty session, mixed present/absent markdown, filename parsing, mtime fallback, non-session dirs ignored).

All 17 new and existing stills tests pass (`node --test test/stills-queue.test.js test/stills-recovery.test.js`). No regressions in the full unit suite.

## Commits

1. `fix: auto-recover stills.db from SQLite corruption` — core detection, quarantine, runtime retry, orphan scan
2. `feat: surface DB recovery as a user-visible toast notification` — callback wiring through recorder/worker/controller/main
3. `test: add corruption recovery and orphan scan coverage`
4. `docs: add troubleshooting note for missing OCR transcripts to familiar skill`

Made with [Cursor](https://cursor.com)